### PR TITLE
Merge http and https mentions

### DIFF
--- a/lib/App/txtnix.pm
+++ b/lib/App/txtnix.pm
@@ -477,11 +477,19 @@ sub display_tweets {
     return;
 }
 
+sub normalize_url {
+	my ($self, $url) = @_;
+	my $ret;
+	$ret = "hxxp:$1" if ($url =~ /https?:(.*)/);
+	#print STDERR "NORMALIZE: $url -> $ret\n";
+	return $ret;
+}
+
 sub url_to_nick {
     my ( $self, $url ) = @_;
     my $known_users = $self->known_users;
-    my %urls = map { $known_users->{$_} => $_ } keys %{$known_users};
-    return $urls{$url};
+    my %urls = map { $self->normalize_url($known_users->{$_}) => $_ } keys %{$known_users};
+    return $urls{$self->normalize_url($url)};
 }
 
 sub collapse_mentions {


### PR DESCRIPTION
## Rather a preview, functional but untidy code.

Let <@user http://tw.txt/> and <@user https://tw.txt/> be considered
equal for the mentions, as this depends on which url random people use,
and cannot be fixed on the config side (as we allow only a single url,
besides that for the protocol in mentions it does not really matter).
